### PR TITLE
Updates to `ThreadingPolicy` to support more threads/reserve some threads for caller

### DIFF
--- a/src/lib/box/box_blur.rs
+++ b/src/lib/box/box_blur.rs
@@ -626,7 +626,7 @@ pub fn box_blur(
     channels: FastBlurChannels,
     threading_policy: ThreadingPolicy,
 ) {
-    let thread_count = threading_policy.get_threads_count(width, height) as u32;
+    let thread_count = threading_policy.thread_count(width, height) as u32;
     let _dispatcher = match channels {
         FastBlurChannels::Plane => box_blur_impl::<u8, 1>,
         FastBlurChannels::Channels3 => box_blur_impl::<u8, 3>,
@@ -681,7 +681,7 @@ pub fn box_blur_u16(
     threading_policy: ThreadingPolicy,
 ) {
     let stride = width * channels.get_channels() as u32;
-    let thread_count = threading_policy.get_threads_count(width, height) as u32;
+    let thread_count = threading_policy.thread_count(width, height) as u32;
     let pool = if thread_count == 1 {
         None
     } else {
@@ -735,7 +735,7 @@ pub fn box_blur_f32(
     threading_policy: ThreadingPolicy,
 ) {
     let stride = width * channels.get_channels() as u32;
-    let thread_count = threading_policy.get_threads_count(width, height) as u32;
+    let thread_count = threading_policy.thread_count(width, height) as u32;
     let pool = if thread_count == 1 {
         None
     } else {
@@ -870,7 +870,7 @@ fn tent_blur_impl<
 ) where
     f32: ToStorage<T>,
 {
-    let thread_count = threading_policy.get_threads_count(width, height) as u32;
+    let thread_count = threading_policy.thread_count(width, height) as u32;
     let pool = if thread_count == 1 {
         None
     } else {
@@ -1152,7 +1152,7 @@ fn gaussian_box_blur_impl<
 ) where
     f32: ToStorage<T>,
 {
-    let thread_count = threading_policy.get_threads_count(width, height) as u32;
+    let thread_count = threading_policy.thread_count(width, height) as u32;
     let pool = if thread_count == 1 {
         None
     } else {

--- a/src/lib/fast_gaussian.rs
+++ b/src/lib/fast_gaussian.rs
@@ -739,7 +739,7 @@ fn fast_gaussian_impl<
     f64: AsPrimitive<T> + ToStorage<T>,
 {
     let unsafe_image = UnsafeSlice::new(bytes);
-    let thread_count = threading_policy.get_threads_count(width, height) as u32;
+    let thread_count = threading_policy.thread_count(width, height) as u32;
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(thread_count as usize)
         .build()

--- a/src/lib/fast_gaussian_next.rs
+++ b/src/lib/fast_gaussian_next.rs
@@ -767,7 +767,7 @@ fn fast_gaussian_next_impl<
         end: u32,
         EdgeMode,
     ) = T::get_horizontal::<CHANNEL_CONFIGURATION>(radius);
-    let thread_count = threading_policy.get_threads_count(width, height) as u32;
+    let thread_count = threading_policy.thread_count(width, height) as u32;
     if thread_count == 1 {
         let unsafe_image = UnsafeSlice::new(bytes);
         _dispatcher_vertical(

--- a/src/lib/fast_gaussian_superior.rs
+++ b/src/lib/fast_gaussian_superior.rs
@@ -483,7 +483,7 @@ pub(crate) fn fast_gaussian_impl<
     f64: ToStorage<T> + AsPrimitive<T>,
 {
     let unsafe_image = UnsafeSlice::new(bytes);
-    let thread_count = threading_policy.get_threads_count(width, height) as u32;
+    let thread_count = threading_policy.thread_count(width, height) as u32;
     if thread_count == 1 {
         fast_gaussian_vertical_pass::<T, CHANNELS_COUNT>(
             &unsafe_image,

--- a/src/lib/filter1d/filter.rs
+++ b/src/lib/filter1d/filter.rs
@@ -111,9 +111,8 @@ where
     let is_column_kernel_symmetrical = is_symmetric_1d(column_kernel);
     let is_row_kernel_symmetrical = is_symmetric_1d(row_kernel);
 
-    let thread_count = threading_policy
-        .get_threads_count(image_size.width as u32, image_size.height as u32)
-        as u32;
+    let thread_count =
+        threading_policy.thread_count(image_size.width as u32, image_size.height as u32) as u32;
     let pool = if thread_count == 1 {
         None
     } else {

--- a/src/lib/filter1d/filter_1d_approx.rs
+++ b/src/lib/filter1d/filter_1d_approx.rs
@@ -138,9 +138,8 @@ where
     let is_column_kernel_symmetric = is_symmetric_1d(column_kernel);
     let is_row_kernel_symmetric = is_symmetric_1d(row_kernel);
 
-    let thread_count = threading_policy
-        .get_threads_count(image_size.width as u32, image_size.height as u32)
-        as u32;
+    let thread_count =
+        threading_policy.thread_count(image_size.width as u32, image_size.height as u32) as u32;
     let pool = if thread_count == 1 {
         None
     } else {

--- a/src/lib/filter1d/filter_1d_rgb.rs
+++ b/src/lib/filter1d/filter_1d_rgb.rs
@@ -111,9 +111,8 @@ where
     let is_column_kernel_symmetrical = is_symmetric_1d(column_kernel);
     let is_row_kernel_symmetrical = is_symmetric_1d(row_kernel);
 
-    let thread_count = threading_policy
-        .get_threads_count(image_size.width as u32, image_size.height as u32)
-        as u32;
+    let thread_count =
+        threading_policy.thread_count(image_size.width as u32, image_size.height as u32) as u32;
     let pool = if thread_count == 1 {
         None
     } else {

--- a/src/lib/filter1d/filter_1d_rgb_approx.rs
+++ b/src/lib/filter1d/filter_1d_rgb_approx.rs
@@ -137,9 +137,8 @@ where
     let is_column_kernel_symmetric = is_symmetric_1d(column_kernel);
     let is_row_kernel_symmetric = is_symmetric_1d(row_kernel);
 
-    let thread_count = threading_policy
-        .get_threads_count(image_size.width as u32, image_size.height as u32)
-        as u32;
+    let thread_count =
+        threading_policy.thread_count(image_size.width as u32, image_size.height as u32) as u32;
     let pool = if thread_count == 1 {
         None
     } else {

--- a/src/lib/filter1d/filter_1d_rgba.rs
+++ b/src/lib/filter1d/filter_1d_rgba.rs
@@ -112,9 +112,8 @@ where
     let is_column_kernel_symmetrical = is_symmetric_1d(column_kernel);
     let is_row_column_kernel_symmetrical = is_symmetric_1d(row_kernel);
 
-    let thread_count = threading_policy
-        .get_threads_count(image_size.width as u32, image_size.height as u32)
-        as u32;
+    let thread_count =
+        threading_policy.thread_count(image_size.width as u32, image_size.height as u32) as u32;
     let pool = if thread_count == 1 {
         None
     } else {

--- a/src/lib/filter1d/filter_1d_rgba_approx.rs
+++ b/src/lib/filter1d/filter_1d_rgba_approx.rs
@@ -139,9 +139,8 @@ where
     let is_column_kernel_symmetric = is_symmetric_1d(column_kernel);
     let is_row_kernel_symmetric = is_symmetric_1d(row_kernel);
 
-    let thread_count = threading_policy
-        .get_threads_count(image_size.width as u32, image_size.height as u32)
-        as u32;
+    let thread_count =
+        threading_policy.thread_count(image_size.width as u32, image_size.height as u32) as u32;
     let pool = if thread_count == 1 {
         None
     } else {

--- a/src/lib/filter2d/filter_2d.rs
+++ b/src/lib/filter2d/filter_2d.rs
@@ -117,9 +117,8 @@ where
         border_constant,
     )?;
 
-    let thread_count = threading_policy
-        .get_threads_count(image_size.width as u32, image_size.height as u32)
-        as u32;
+    let thread_count =
+        threading_policy.thread_count(image_size.width as u32, image_size.height as u32) as u32;
     let pool = if thread_count == 1 {
         None
     } else {

--- a/src/lib/median_blur.rs
+++ b/src/lib/median_blur.rs
@@ -320,7 +320,7 @@ pub fn median_blur(
         FastBlurChannels::Channels3 => median_blur_impl::<3>,
         FastBlurChannels::Channels4 => median_blur_impl::<4>,
     };
-    let thread_count = threading_policy.get_threads_count(width, height) as u32;
+    let thread_count = threading_policy.thread_count(width, height) as u32;
     if thread_count == 1 {
         _dispatcher(
             src,

--- a/src/lib/stackblur/stack_blur.rs
+++ b/src/lib/stackblur/stack_blur.rs
@@ -214,7 +214,7 @@ pub fn stack_blur(
 ) {
     #[allow(clippy::manual_clamp)]
     let radius = radius.max(1).min(1449);
-    let thread_count = threading_policy.get_threads_count(width, height) as u32;
+    let thread_count = threading_policy.thread_count(width, height) as u32;
     if thread_count == 1 {
         let slice = UnsafeSlice::new(in_place);
         stack_blur_worker_horizontal(&slice, stride, width, height, radius, channels, 0, 1);

--- a/src/lib/stackblur/stack_blur_f16.rs
+++ b/src/lib/stackblur/stack_blur_f16.rs
@@ -189,7 +189,7 @@ pub fn stack_blur_f16(
 ) {
     let radius = radius.max(1);
     let stride = width * channels.get_channels() as u32;
-    let thread_count = threading_policy.get_threads_count(width, height) as u32;
+    let thread_count = threading_policy.thread_count(width, height) as u32;
     if thread_count == 1 {
         let slice = UnsafeSlice::new(in_place);
         stack_blur_worker_horizontal(&slice, stride, width, height, radius, channels, 0, 1);

--- a/src/lib/stackblur/stack_blur_f32.rs
+++ b/src/lib/stackblur/stack_blur_f32.rs
@@ -186,7 +186,7 @@ pub fn stack_blur_f32(
     let radius = radius.max(1);
     let stride = width * channels.get_channels() as u32;
     let radius = std::cmp::max(radius, 2);
-    let thread_count = threading_policy.get_threads_count(width, height) as u32;
+    let thread_count = threading_policy.thread_count(width, height) as u32;
     if thread_count == 1 {
         let slice = UnsafeSlice::new(in_place);
         stack_blur_worker_horizontal(&slice, stride, width, height, radius, channels, 0, 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,12 @@ use crate::merge::merge_channels_3;
 use crate::split::split_channels_3;
 use colorutils_rs::TransferFunction;
 use image::{EncodableLayout, GenericImageView, ImageReader};
-use libblur::{adaptive_blur, fast_bilateral_filter, filter_1d_approx, filter_1d_exact, filter_1d_rgb_approx, filter_1d_rgb_exact, filter_2d_rgb_fft, filter_2d_rgba_fft, generate_motion_kernel, get_gaussian_kernel_1d, get_sigma_size, motion_blur, EdgeMode, FastBlurChannels, GaussianPreciseLevel, ImageSize, KernelShape, Scalar, ThreadingPolicy};
+use libblur::{
+    adaptive_blur, fast_bilateral_filter, filter_1d_approx, filter_1d_exact, filter_1d_rgb_approx,
+    filter_1d_rgb_exact, filter_2d_rgb_fft, filter_2d_rgba_fft, generate_motion_kernel,
+    get_gaussian_kernel_1d, get_sigma_size, motion_blur, EdgeMode, FastBlurChannels,
+    GaussianPreciseLevel, ImageSize, KernelShape, Scalar, ThreadingPolicy,
+};
 use std::time::Instant;
 
 #[allow(dead_code)]


### PR DESCRIPTION
* Removed 12 thread limit/changed `ThreadingPolicy::Adaptive` to use the detected number of CPUs via [`std::thread::available_parallelism()`](https://doc.rust-lang.org/std/thread/fn.available_parallelism.html).
* Added `ThreadingPolicy::AdaptiveReserve`. This uses the value from `Adaptive` minus the reserved number of threads or a single thread if the number is larger than `available_parallelism`.
* Renamed `get_threads_count()` to `thread_count()`.
* Ran `cargo fmt`.
* On platforms where `available_parallelism()` returns `Err`, `1` is returned by `Adaptive`/`AdaptiveReserve`'s `thread_count()` invocation.

> ~~Note: `thread_count()` will panic on platforms where `available_parallelism()` returns `Err`.
See the [`Errors`]( https://doc.rust-lang.org/std/thread/fn.available_parallelism.html#errors) section of `available_parallelism` . I think this is acceptable as this is not going to happen on the platforms this crate is intended/optimized for.~~
> ~~But if you think this case should be covered I can change the code to return a safe default, `1`, in this case.~~