### PR TITLE
Removed `get_` prefixes

### DIFF
--- a/benches/gauss/main.rs
+++ b/benches/gauss/main.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use image::{GenericImageView, ImageReader};
 use libblur::{
-    filter_1d_rgb_exact, get_gaussian_kernel_1d, get_sigma_size, ConvolutionMode, EdgeMode,
+    filter_1d_rgb_exact, gaussian_kernel_1d, get_sigma_size, ConvolutionMode, EdgeMode,
     FastBlurChannels, ImageSize, Scalar, ThreadingPolicy,
 };
 use opencv::core::{find_file, split, AlgorithmHint, Mat, Size, Vector, BORDER_DEFAULT};
@@ -226,7 +226,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         c.bench_function("Filter 2D Rgb Blur Clamp: 25", |b| {
             let mut dst_bytes: Vec<u8> = vec![0u8; dimensions.1 as usize * stride];
-            let kernel = get_gaussian_kernel_1d(25, get_sigma_size(25));
+            let kernel = gaussian_kernel_1d(25, get_sigma_size(25));
             b.iter(|| {
                 filter_1d_rgb_exact(
                     src_bytes,
@@ -244,7 +244,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         c.bench_function("Filter 2D Rgb Blur Clamp: 151", |b| {
             let mut dst_bytes: Vec<u8> = vec![0u8; dimensions.1 as usize * stride];
-            let kernel = get_gaussian_kernel_1d(151, get_sigma_size(151));
+            let kernel = gaussian_kernel_1d(151, get_sigma_size(151));
             b.iter(|| {
                 filter_1d_rgb_exact(
                     src_bytes,

--- a/fuzz/box/box.rs
+++ b/fuzz/box/box.rs
@@ -57,14 +57,14 @@ fn fuzz_8bit(width: usize, height: usize, radius: usize, channels: FastBlurChann
     if width == 0 || height == 0 || radius == 0 {
         return;
     }
-    let src_image = vec![15u8; width * height * channels.get_channels()];
-    let mut dst_image = vec![0u8; width * height * channels.get_channels()];
+    let src_image = vec![15u8; width * height * channels.channels()];
+    let mut dst_image = vec![0u8; width * height * channels.channels()];
 
     libblur::box_blur(
         &src_image,
-        width as u32 * channels.get_channels() as u32,
+        width as u32 * channels.channels() as u32,
         &mut dst_image,
-        width as u32 * channels.get_channels() as u32,
+        width as u32 * channels.channels() as u32,
         width as u32,
         height as u32,
         radius as u32 * 2 + 1,

--- a/fuzz/fast_gaussian/fast_gaussian.rs
+++ b/fuzz/fast_gaussian/fast_gaussian.rs
@@ -57,10 +57,10 @@ fn fuzz_image(width: usize, height: usize, radius: usize, channels: FastBlurChan
     if width == 0 || height == 0 || radius == 0 {
         return;
     }
-    let mut dst_image = vec![15u8; width * height * channels.get_channels()];
+    let mut dst_image = vec![15u8; width * height * channels.channels()];
     fast_gaussian(
         &mut dst_image,
-        width as u32 * channels.get_channels() as u32,
+        width as u32 * channels.channels() as u32,
         width as u32,
         height as u32,
         radius as u32,

--- a/fuzz/fast_gaussian_f32/fast_gaussian_f32.rs
+++ b/fuzz/fast_gaussian_f32/fast_gaussian_f32.rs
@@ -57,10 +57,10 @@ fn fuzz_image(width: usize, height: usize, radius: usize, channels: FastBlurChan
     if width == 0 || height == 0 || radius == 0 {
         return;
     }
-    let mut dst_image = vec![0.1f32; width * height * channels.get_channels()];
+    let mut dst_image = vec![0.1f32; width * height * channels.channels()];
     fast_gaussian_f32(
         &mut dst_image,
-        width as u32 * channels.get_channels() as u32,
+        width as u32 * channels.channels() as u32,
         width as u32,
         height as u32,
         radius as u32,

--- a/fuzz/fast_gaussian_next/fast_gaussian_next.rs
+++ b/fuzz/fast_gaussian_next/fast_gaussian_next.rs
@@ -57,10 +57,10 @@ fn fuzz_image(width: usize, height: usize, radius: usize, channels: FastBlurChan
     if width == 0 || height == 0 || radius == 0 {
         return;
     }
-    let mut dst_image = vec![15u8; width * height * channels.get_channels()];
+    let mut dst_image = vec![15u8; width * height * channels.channels()];
     fast_gaussian_next(
         &mut dst_image,
-        width as u32 * channels.get_channels() as u32,
+        width as u32 * channels.channels() as u32,
         width as u32,
         height as u32,
         radius as u32,

--- a/fuzz/fast_gaussian_u16/fast_gaussian_u16.rs
+++ b/fuzz/fast_gaussian_u16/fast_gaussian_u16.rs
@@ -57,10 +57,10 @@ fn fuzz_image(width: usize, height: usize, radius: usize, channels: FastBlurChan
     if width == 0 || height == 0 || radius == 0 {
         return;
     }
-    let mut dst_image = vec![1u16; width * height * channels.get_channels()];
+    let mut dst_image = vec![1u16; width * height * channels.channels()];
     fast_gaussian_u16(
         &mut dst_image,
-        width as u32 * channels.get_channels() as u32,
+        width as u32 * channels.channels() as u32,
         width as u32,
         height as u32,
         radius as u32,

--- a/fuzz/gauss/gauss.rs
+++ b/fuzz/gauss/gauss.rs
@@ -31,7 +31,7 @@
 
 use libblur::{
     filter_1d_approx, filter_1d_exact, filter_1d_rgb_approx, filter_1d_rgb_exact,
-    filter_1d_rgba_approx, filter_1d_rgba_exact, get_gaussian_kernel_1d, get_sigma_size,
+    filter_1d_rgba_approx, filter_1d_rgba_exact, gaussian_kernel_1d, get_sigma_size,
     ConvolutionMode, EdgeMode, FastBlurChannels, ImageSize, Scalar, ThreadingPolicy,
 };
 use libfuzzer_sys::fuzz_target;
@@ -79,8 +79,8 @@ fn fuzz_8bit(width: usize, height: usize, radius: usize, channels: FastBlurChann
     if width == 0 || height == 0 || radius == 0 {
         return;
     }
-    let src_image = vec![15u8; width * height * channels.get_channels()];
-    let mut dst_image = vec![0u8; width * height * channels.get_channels()];
+    let src_image = vec![15u8; width * height * channels.channels()];
+    let mut dst_image = vec![0u8; width * height * channels.channels()];
 
     libblur::gaussian_blur(
         &src_image,
@@ -115,12 +115,12 @@ fn fuzz_8bit_non_symmetry(width: usize, height: usize, radius: usize, channels: 
     if width == 0 || height == 0 || radius == 0 {
         return;
     }
-    let src_image = vec![15u8; width * height * channels.get_channels()];
-    let mut dst_image = vec![0u8; width * height * channels.get_channels()];
+    let src_image = vec![15u8; width * height * channels.channels()];
+    let mut dst_image = vec![0u8; width * height * channels.channels()];
 
     let kernel_size = radius * 2 + 1;
 
-    let kernel = get_gaussian_kernel_1d(kernel_size as u32, get_sigma_size(kernel_size));
+    let kernel = gaussian_kernel_1d(kernel_size as u32, get_sigma_size(kernel_size));
 
     match channels {
         FastBlurChannels::Plane => {

--- a/fuzz/gauss_f32/gauss_f32.rs
+++ b/fuzz/gauss_f32/gauss_f32.rs
@@ -57,8 +57,8 @@ fn fuzz_f32(width: usize, height: usize, radius: usize, channels: FastBlurChanne
     if width == 0 || height == 0 || radius == 0 {
         return;
     }
-    let src_image = vec![0.5f32; width * height * channels.get_channels()];
-    let mut dst_image = vec![0f32; width * height * channels.get_channels()];
+    let src_image = vec![0.5f32; width * height * channels.channels()];
+    let mut dst_image = vec![0f32; width * height * channels.channels()];
 
     libblur::gaussian_blur_f32(
         &src_image,

--- a/fuzz/gauss_u16/gauss_u16.rs
+++ b/fuzz/gauss_u16/gauss_u16.rs
@@ -57,8 +57,8 @@ fn fuzz_16bit(width: usize, height: usize, radius: usize, channels: FastBlurChan
     if width == 0 || height == 0 || radius == 0 {
         return;
     }
-    let src_image = vec![15u16; width * height * channels.get_channels()];
-    let mut dst_image = vec![0u16; width * height * channels.get_channels()];
+    let src_image = vec![15u16; width * height * channels.channels()];
+    let mut dst_image = vec![0u16; width * height * channels.channels()];
 
     libblur::gaussian_blur_u16(
         &src_image,

--- a/fuzz/stack_blur/stack_blur.rs
+++ b/fuzz/stack_blur/stack_blur.rs
@@ -57,10 +57,10 @@ fn fuzz_image(width: usize, height: usize, radius: usize, channels: FastBlurChan
     if width == 0 || height == 0 || radius == 0 {
         return;
     }
-    let mut dst_image = vec![15u8; width * height * channels.get_channels()];
+    let mut dst_image = vec![15u8; width * height * channels.channels()];
     stack_blur(
         &mut dst_image,
-        width as u32 * channels.get_channels() as u32,
+        width as u32 * channels.channels() as u32,
         width as u32,
         height as u32,
         radius as u32,

--- a/fuzz/stack_blur_f32/stack_blur_f32.rs
+++ b/fuzz/stack_blur_f32/stack_blur_f32.rs
@@ -57,10 +57,10 @@ fn fuzz_image(width: usize, height: usize, radius: usize, channels: FastBlurChan
     if width == 0 || height == 0 || radius == 0 {
         return;
     }
-    let mut dst_image = vec![0.2f32; width * height * channels.get_channels()];
+    let mut dst_image = vec![0.2f32; width * height * channels.channels()];
     stack_blur_f32(
         &mut dst_image,
-        width as u32 * channels.get_channels() as u32,
+        width as u32 * channels.channels() as u32,
         width as u32,
         height as u32,
         radius as u32,

--- a/fuzz/stack_blur_u16/stack_blur_u16.rs
+++ b/fuzz/stack_blur_u16/stack_blur_u16.rs
@@ -57,10 +57,10 @@ fn fuzz_image(width: usize, height: usize, radius: usize, channels: FastBlurChan
     if width == 0 || height == 0 || radius == 0 {
         return;
     }
-    let mut dst_image = vec![15u16; width * height * channels.get_channels()];
+    let mut dst_image = vec![15u16; width * height * channels.channels()];
     stack_blur_u16(
         &mut dst_image,
-        width as u32 * channels.get_channels() as u32,
+        width as u32 * channels.channels() as u32,
         width as u32,
         height as u32,
         radius as u32,
@@ -70,7 +70,7 @@ fn fuzz_image(width: usize, height: usize, radius: usize, channels: FastBlurChan
     .unwrap();
     stack_blur_u16(
         &mut dst_image,
-        width as u32 * channels.get_channels() as u32,
+        width as u32 * channels.channels() as u32,
         width as u32,
         height as u32,
         radius as u32 + 500,

--- a/src/lib/box_filter/box_blur.rs
+++ b/src/lib/box_filter/box_blur.rs
@@ -819,19 +819,19 @@ pub fn box_blur_in_linear(
         src_stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     check_slice_size(
         dst,
         dst_stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let mut linear_data: Vec<f32> =
-        vec![0f32; width as usize * height as usize * channels.get_channels()];
+        vec![0f32; width as usize * height as usize * channels.channels()];
     let mut linear_data_2: Vec<f32> =
-        vec![0f32; width as usize * height as usize * channels.get_channels()];
+        vec![0f32; width as usize * height as usize * channels.channels()];
 
     let forward_transformer = match channels {
         FastBlurChannels::Plane => plane_to_linear,
@@ -849,7 +849,7 @@ pub fn box_blur_in_linear(
         src,
         src_stride,
         &mut linear_data,
-        width * std::mem::size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * std::mem::size_of::<f32>() as u32 * channels.channels() as u32,
         width,
         height,
         transfer_function,
@@ -857,9 +857,9 @@ pub fn box_blur_in_linear(
 
     box_blur_f32(
         &linear_data,
-        width * channels.get_channels() as u32,
+        width * channels.channels() as u32,
         &mut linear_data_2,
-        width * channels.get_channels() as u32,
+        width * channels.channels() as u32,
         width,
         height,
         radius,
@@ -869,7 +869,7 @@ pub fn box_blur_in_linear(
 
     inverse_transformer(
         &linear_data_2,
-        width * std::mem::size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * std::mem::size_of::<f32>() as u32 * channels.channels() as u32,
         dst,
         dst_stride,
         width,
@@ -1180,19 +1180,19 @@ pub fn tent_blur_in_linear(
         src_stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     check_slice_size(
         dst,
         dst_stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let mut linear_data: Vec<f32> =
-        vec![0f32; width as usize * height as usize * channels.get_channels()];
+        vec![0f32; width as usize * height as usize * channels.channels()];
     let mut linear_data_2: Vec<f32> =
-        vec![0f32; width as usize * height as usize * channels.get_channels()];
+        vec![0f32; width as usize * height as usize * channels.channels()];
 
     let forward_transformer = match channels {
         FastBlurChannels::Plane => plane_to_linear,
@@ -1210,7 +1210,7 @@ pub fn tent_blur_in_linear(
         src,
         src_stride,
         &mut linear_data,
-        width * std::mem::size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * std::mem::size_of::<f32>() as u32 * channels.channels() as u32,
         width,
         height,
         transfer_function,
@@ -1218,9 +1218,9 @@ pub fn tent_blur_in_linear(
 
     tent_blur_f32(
         &linear_data,
-        width * channels.get_channels() as u32,
+        width * channels.channels() as u32,
         &mut linear_data_2,
-        width * channels.get_channels() as u32,
+        width * channels.channels() as u32,
         width,
         height,
         sigma,
@@ -1230,7 +1230,7 @@ pub fn tent_blur_in_linear(
 
     inverse_transformer(
         &linear_data_2,
-        width * std::mem::size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * std::mem::size_of::<f32>() as u32 * channels.channels() as u32,
         dst,
         dst_stride,
         width,
@@ -1513,19 +1513,19 @@ pub fn gaussian_box_blur_in_linear(
         src_stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     check_slice_size(
         dst,
         dst_stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let mut linear_data: Vec<f32> =
-        vec![0f32; width as usize * height as usize * channels.get_channels()];
+        vec![0f32; width as usize * height as usize * channels.channels()];
     let mut linear_data_2: Vec<f32> =
-        vec![0f32; width as usize * height as usize * channels.get_channels()];
+        vec![0f32; width as usize * height as usize * channels.channels()];
 
     let forward_transformer = match channels {
         FastBlurChannels::Plane => plane_to_linear,
@@ -1543,7 +1543,7 @@ pub fn gaussian_box_blur_in_linear(
         src,
         src_stride,
         &mut linear_data,
-        width * std::mem::size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * std::mem::size_of::<f32>() as u32 * channels.channels() as u32,
         width,
         height,
         transfer_function,
@@ -1551,9 +1551,9 @@ pub fn gaussian_box_blur_in_linear(
 
     gaussian_box_blur_f32(
         &linear_data,
-        width * channels.get_channels() as u32,
+        width * channels.channels() as u32,
         &mut linear_data_2,
-        width * channels.get_channels() as u32,
+        width * channels.channels() as u32,
         width,
         height,
         sigma,
@@ -1563,7 +1563,7 @@ pub fn gaussian_box_blur_in_linear(
 
     inverse_transformer(
         &linear_data_2,
-        width * std::mem::size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * std::mem::size_of::<f32>() as u32 * channels.channels() as u32,
         dst,
         dst_stride,
         width,

--- a/src/lib/channels_configuration.rs
+++ b/src/lib/channels_configuration.rs
@@ -45,7 +45,7 @@ pub enum FastBlurChannels {
 }
 
 impl FastBlurChannels {
-    pub const fn get_channels(&self) -> usize {
+    pub const fn channels(&self) -> usize {
         match self {
             FastBlurChannels::Plane => 1,
             FastBlurChannels::Channels3 => 3,

--- a/src/lib/fast_bilateral_filter.rs
+++ b/src/lib/fast_bilateral_filter.rs
@@ -26,7 +26,7 @@
  * // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-use crate::gaussian::get_gaussian_kernel_1d;
+use crate::gaussian::gaussian_kernel_1d;
 use crate::util::check_slice_size;
 use crate::{BlurError, FastBlurChannels};
 use num_traits::real::Real;
@@ -384,7 +384,7 @@ fn fast_bilateral_filter_impl<
 
     let preferred_sigma = (spatial_sigma * spatial_sigma + range_sigma * range_sigma).sqrt();
 
-    let gaussian_kernel = get_gaussian_kernel_1d(kernel_size, preferred_sigma);
+    let gaussian_kernel = gaussian_kernel_1d(kernel_size, preferred_sigma);
     let half_kernel = gaussian_kernel.len() / 2;
 
     // Unrolled 3D convolution
@@ -988,10 +988,10 @@ pub fn fast_bilateral_filter(
 ) -> Result<(), BlurError> {
     check_slice_size(
         img,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     assert_ne!(kernel_size & 1, 0, "kernel_size must be odd");
     match channels {
@@ -1061,10 +1061,10 @@ pub fn fast_bilateral_filter_u16(
 ) -> Result<(), BlurError> {
     check_slice_size(
         img,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     if kernel_size & 1 == 0 {
         panic!("kernel_size must be odd");
@@ -1136,10 +1136,10 @@ pub fn fast_bilateral_filter_f32(
 ) -> Result<(), BlurError> {
     check_slice_size(
         img,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     if kernel_size & 1 == 0 {
         panic!("kernel_size must be odd");

--- a/src/lib/fast_gaussian.rs
+++ b/src/lib/fast_gaussian.rs
@@ -877,7 +877,7 @@ pub fn fast_gaussian(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let radius = std::cmp::min(radius, 319);
     impl_margin_call!(
@@ -926,7 +926,7 @@ pub fn fast_gaussian_u16(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let radius = std::cmp::min(radius, 255);
     impl_margin_call!(
@@ -976,7 +976,7 @@ pub fn fast_gaussian_f32(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     impl_margin_call!(
         f32,
@@ -1027,10 +1027,10 @@ pub fn fast_gaussian_in_linear(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let mut linear_data: Vec<f32> =
-        vec![0f32; width as usize * height as usize * channels.get_channels()];
+        vec![0f32; width as usize * height as usize * channels.channels()];
 
     let forward_transformer = match channels {
         FastBlurChannels::Plane => plane_to_linear,
@@ -1048,7 +1048,7 @@ pub fn fast_gaussian_in_linear(
         in_place,
         stride,
         &mut linear_data,
-        width * std::mem::size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * std::mem::size_of::<f32>() as u32 * channels.channels() as u32,
         width,
         height,
         transfer_function,
@@ -1056,7 +1056,7 @@ pub fn fast_gaussian_in_linear(
 
     fast_gaussian_f32(
         &mut linear_data,
-        width * channels.get_channels() as u32,
+        width * channels.channels() as u32,
         width,
         height,
         radius,
@@ -1067,7 +1067,7 @@ pub fn fast_gaussian_in_linear(
 
     inverse_transformer(
         &linear_data,
-        width * std::mem::size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * std::mem::size_of::<f32>() as u32 * channels.channels() as u32,
         in_place,
         stride,
         width,
@@ -1110,14 +1110,14 @@ pub fn fast_gaussian_f16(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     impl_margin_call!(
         half::f16,
         channels,
         edge_mode,
         bytes,
-        width * channels.get_channels() as u32,
+        width * channels.channels() as u32,
         width,
         height,
         radius,

--- a/src/lib/fast_gaussian_next.rs
+++ b/src/lib/fast_gaussian_next.rs
@@ -897,7 +897,7 @@ pub fn fast_gaussian_next(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let radius = std::cmp::min(radius, 280);
     impl_margin_call!(
@@ -947,7 +947,7 @@ pub fn fast_gaussian_next_u16(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let acq_radius = std::cmp::min(radius, 152);
     impl_margin_call!(
@@ -996,7 +996,7 @@ pub fn fast_gaussian_next_f32(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     impl_margin_call!(
         f32,
@@ -1044,7 +1044,7 @@ pub fn fast_gaussian_next_f16(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     impl_margin_call!(
         half::f16,
@@ -1094,10 +1094,10 @@ pub fn fast_gaussian_next_in_linear(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let mut linear_data: Vec<f32> =
-        vec![0f32; width as usize * height as usize * channels.get_channels()];
+        vec![0f32; width as usize * height as usize * channels.channels()];
 
     let forward_transformer = match channels {
         FastBlurChannels::Plane => plane_to_linear,
@@ -1115,7 +1115,7 @@ pub fn fast_gaussian_next_in_linear(
         in_place,
         stride,
         &mut linear_data,
-        width * size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * size_of::<f32>() as u32 * channels.channels() as u32,
         width,
         height,
         transfer_function,
@@ -1123,7 +1123,7 @@ pub fn fast_gaussian_next_in_linear(
 
     fast_gaussian_next_f32(
         &mut linear_data,
-        width * channels.get_channels() as u32,
+        width * channels.channels() as u32,
         width,
         height,
         radius,
@@ -1134,7 +1134,7 @@ pub fn fast_gaussian_next_in_linear(
 
     inverse_transformer(
         &linear_data,
-        width * size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * size_of::<f32>() as u32 * channels.channels() as u32,
         in_place,
         stride,
         width,

--- a/src/lib/gaussian/declaration.rs
+++ b/src/lib/gaussian/declaration.rs
@@ -27,13 +27,13 @@
 
 use crate::channels_configuration::FastBlurChannels;
 use crate::edge_mode::EdgeMode;
-use crate::gaussian::gaussian_kernel::get_gaussian_kernel_1d;
-use crate::gaussian::gaussian_util::get_kernel_size;
+use crate::gaussian::gaussian_kernel::gaussian_kernel_1d;
+use crate::gaussian::gaussian_util::kernel_size as get_kernel_size;
 use crate::util::check_slice_size;
 use crate::{
     filter_1d_approx, filter_1d_exact, filter_1d_rgb_approx, filter_1d_rgb_exact,
-    filter_1d_rgba_approx, filter_1d_rgba_exact, get_sigma_size, BlurError, ConvolutionMode,
-    ImageSize, Scalar, ThreadingPolicy,
+    filter_1d_rgba_approx, filter_1d_rgba_exact, sigma_size, BlurError, ConvolutionMode, ImageSize,
+    Scalar, ThreadingPolicy,
 };
 use half::f16;
 
@@ -73,17 +73,17 @@ pub fn gaussian_blur(
 ) -> Result<(), BlurError> {
     check_slice_size(
         src,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     check_slice_size(
         dst,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     assert!(
         kernel_size != 0 || sigma > 0.0,
@@ -93,7 +93,7 @@ pub fn gaussian_blur(
         assert_ne!(kernel_size % 2, 0, "Kernel size must be odd");
     }
     let sigma = if sigma <= 0. {
-        get_sigma_size(kernel_size as usize)
+        sigma_size(kernel_size as usize)
     } else {
         sigma
     };
@@ -102,7 +102,7 @@ pub fn gaussian_blur(
     } else {
         kernel_size
     };
-    let kernel = get_gaussian_kernel_1d(kernel_size, sigma);
+    let kernel = gaussian_kernel_1d(kernel_size, sigma);
     match hint {
         ConvolutionMode::Exact => {
             let _dispatcher = match channels {
@@ -174,17 +174,17 @@ pub fn gaussian_blur_u16(
 ) -> Result<(), BlurError> {
     check_slice_size(
         src,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     check_slice_size(
         dst,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     assert!(
         kernel_size != 0 || sigma > 0.0,
@@ -194,7 +194,7 @@ pub fn gaussian_blur_u16(
         assert_ne!(kernel_size % 2, 0, "Kernel size must be odd");
     }
     let sigma = if sigma <= 0. {
-        get_sigma_size(kernel_size as usize)
+        sigma_size(kernel_size as usize)
     } else {
         sigma
     };
@@ -203,7 +203,7 @@ pub fn gaussian_blur_u16(
     } else {
         kernel_size
     };
-    let kernel = get_gaussian_kernel_1d(kernel_size, sigma);
+    let kernel = gaussian_kernel_1d(kernel_size, sigma);
     let _dispatcher = match channels {
         FastBlurChannels::Plane => filter_1d_exact::<u16, f32>,
         FastBlurChannels::Channels3 => filter_1d_rgb_exact::<u16, f32>,
@@ -254,17 +254,17 @@ pub fn gaussian_blur_f32(
 ) -> Result<(), BlurError> {
     check_slice_size(
         src,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     check_slice_size(
         dst,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     assert!(
         kernel_size != 0 || sigma > 0.0,
@@ -274,7 +274,7 @@ pub fn gaussian_blur_f32(
         assert_ne!(kernel_size % 2, 0, "Kernel size must be odd");
     }
     let sigma = if sigma <= 0. {
-        get_sigma_size(kernel_size as usize)
+        sigma_size(kernel_size as usize)
     } else {
         sigma
     };
@@ -283,7 +283,7 @@ pub fn gaussian_blur_f32(
     } else {
         kernel_size
     };
-    let kernel = get_gaussian_kernel_1d(kernel_size, sigma);
+    let kernel = gaussian_kernel_1d(kernel_size, sigma);
     let _dispatcher = match channels {
         FastBlurChannels::Plane => filter_1d_exact::<f32, f32>,
         FastBlurChannels::Channels3 => filter_1d_rgb_exact::<f32, f32>,
@@ -333,17 +333,17 @@ pub fn gaussian_blur_f16(
 ) -> Result<(), BlurError> {
     check_slice_size(
         src,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     check_slice_size(
         dst,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     assert!(
         kernel_size != 0 || sigma > 0.0,
@@ -353,7 +353,7 @@ pub fn gaussian_blur_f16(
         assert_ne!(kernel_size % 2, 0, "Kernel size must be odd");
     }
     let sigma = if sigma <= 0. {
-        get_sigma_size(kernel_size as usize)
+        sigma_size(kernel_size as usize)
     } else {
         sigma
     };
@@ -362,7 +362,7 @@ pub fn gaussian_blur_f16(
     } else {
         kernel_size
     };
-    let kernel = get_gaussian_kernel_1d(kernel_size, sigma);
+    let kernel = gaussian_kernel_1d(kernel_size, sigma);
     let _dispatcher = match channels {
         FastBlurChannels::Plane => filter_1d_exact::<f16, f32>,
         FastBlurChannels::Channels3 => filter_1d_rgb_exact::<f16, f32>,

--- a/src/lib/gaussian/gaussian_kernel.rs
+++ b/src/lib/gaussian/gaussian_kernel.rs
@@ -25,7 +25,7 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub fn get_gaussian_kernel_1d(width: u32, sigma: f32) -> Vec<f32> {
+pub fn gaussian_kernel_1d(width: u32, sigma: f32) -> Vec<f32> {
     let mut sum_norm: f32 = 0f32;
     let mut kernel: Vec<f32> = vec![0f32; width as usize];
     let scale = 1f32 / (f32::sqrt(2f32 * std::f32::consts::PI) * sigma);

--- a/src/lib/gaussian/gaussian_linear.rs
+++ b/src/lib/gaussian/gaussian_linear.rs
@@ -27,7 +27,7 @@
 
 use crate::util::check_slice_size;
 use crate::{
-    gaussian_blur_f32, get_sigma_size, BlurError, EdgeMode, FastBlurChannels, ThreadingPolicy,
+    gaussian_blur_f32, sigma_size, BlurError, EdgeMode, FastBlurChannels, ThreadingPolicy,
 };
 use colorutils_rs::linear_to_planar::linear_to_plane;
 use colorutils_rs::planar_to_linear::plane_to_linear;
@@ -74,22 +74,22 @@ pub fn gaussian_blur_in_linear(
 ) -> Result<(), BlurError> {
     check_slice_size(
         src,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     check_slice_size(
         dst,
-        width as usize * channels.get_channels(),
+        width as usize * channels.channels(),
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let mut linear_data: Vec<f32> =
-        vec![0f32; width as usize * height as usize * channels.get_channels()];
+        vec![0f32; width as usize * height as usize * channels.channels()];
     let mut linear_data_1: Vec<f32> =
-        vec![0f32; width as usize * height as usize * channels.get_channels()];
+        vec![0f32; width as usize * height as usize * channels.channels()];
 
     let forward_transformer = match channels {
         FastBlurChannels::Plane => plane_to_linear,
@@ -107,14 +107,14 @@ pub fn gaussian_blur_in_linear(
         src,
         src_stride,
         &mut linear_data,
-        width * size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * size_of::<f32>() as u32 * channels.channels() as u32,
         width,
         height,
         transfer_function,
     );
 
     let sigma = if sigma <= 0. {
-        get_sigma_size(kernel_size as usize)
+        sigma_size(kernel_size as usize)
     } else {
         sigma
     };
@@ -132,7 +132,7 @@ pub fn gaussian_blur_in_linear(
     )?;
     inverse_transformer(
         &linear_data_1,
-        width * size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * size_of::<f32>() as u32 * channels.channels() as u32,
         dst,
         dst_stride,
         width,

--- a/src/lib/gaussian/gaussian_util.rs
+++ b/src/lib/gaussian/gaussian_util.rs
@@ -28,7 +28,7 @@
  */
 
 /// Computes sigma from kernel size
-pub fn get_sigma_size(kernel_size: usize) -> f32 {
+pub fn sigma_size(kernel_size: usize) -> f32 {
     let safe_kernel_size = if kernel_size as f32 <= 1. {
         2.
     } else {
@@ -38,7 +38,7 @@ pub fn get_sigma_size(kernel_size: usize) -> f32 {
 }
 
 /// Computes kernel size from sigma
-pub fn get_kernel_size(sigma: f32) -> u32 {
+pub fn kernel_size(sigma: f32) -> u32 {
     assert_ne!(sigma, 0.8f32);
     let possible_size = (((((sigma - 0.8f32) / 0.3f32) + 1f32) * 2f32) + 1f32).max(3f32) as u32;
     if possible_size % 2 == 0 {

--- a/src/lib/gaussian/mod.rs
+++ b/src/lib/gaussian/mod.rs
@@ -33,6 +33,6 @@ mod gaussian_util;
 
 pub use declaration::*;
 pub use gaussian_hint::ConvolutionMode;
-pub use gaussian_kernel::get_gaussian_kernel_1d;
+pub use gaussian_kernel::gaussian_kernel_1d;
 pub use gaussian_linear::gaussian_blur_in_linear;
-pub use gaussian_util::get_sigma_size;
+pub use gaussian_util::sigma_size;

--- a/src/lib/laplacian.rs
+++ b/src/lib/laplacian.rs
@@ -1,43 +1,45 @@
 /*
  * // Copyright (c) Radzivon Bartoshyk. All rights reserved.
  * //
- * // Redistribution and use in source and binary forms, with or without modification,
- * // are permitted provided that the following conditions are met:
+ * // Redistribution and use in source and binary forms, with or without
+ * modification, // are permitted provided that the following conditions are
+ * met: //
+ * // 1.  Redistributions of source code must retain the above copyright
+ * notice, this // list of conditions and the following disclaimer.
  * //
- * // 1.  Redistributions of source code must retain the above copyright notice, this
- * // list of conditions and the following disclaimer.
- * //
- * // 2.  Redistributions in binary form must reproduce the above copyright notice,
- * // this list of conditions and the following disclaimer in the documentation
- * // and/or other materials provided with the distribution.
+ * // 2.  Redistributions in binary form must reproduce the above copyright
+ * notice, // this list of conditions and the following disclaimer in the
+ * documentation // and/or other materials provided with the distribution.
  * //
  * // 3.  Neither the name of the copyright holder nor the names of its
  * // contributors may be used to endorse or promote products derived from
  * // this software without specific prior written permission.
  * //
- * // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * // FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * // DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE // FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * // DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE // OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 use crate::{
-    filter_2d, filter_2d_rgb, filter_2d_rgba, get_sigma_size, BlurError, EdgeMode,
-    FastBlurChannels, ImageSize, KernelShape, Scalar, ThreadingPolicy,
+    filter_2d, filter_2d_rgb, filter_2d_rgba, sigma_size, BlurError, EdgeMode, FastBlurChannels,
+    ImageSize, KernelShape, Scalar, ThreadingPolicy,
 };
 
-pub fn get_laplacian_kernel(size: usize) -> Vec<f32> {
+pub fn laplacian_kernel(size: usize) -> Vec<f32> {
     if size & 1 == 0 {
         panic!("Kernel size must be odd in 'get_laplacian_kernel'!");
     }
     let center_x = (size / 2) as f32;
     let center_y = (size / 2) as f32;
-    let sigma = get_sigma_size(size);
+    let sigma = sigma_size(size);
 
     let mut kernel = vec![f32::default(); size * size];
 
@@ -78,12 +80,12 @@ pub fn get_laplacian_kernel(size: usize) -> Vec<f32> {
 /// * `destination_stride`: Destination image stride.
 /// * `image_size`: Image size, see [ImageSize]
 /// * `border_mode`: See [EdgeMode] for more info
-/// * `border_constant`: If [EdgeMode::Constant] border will be replaced with this provided [Scalar] value
+/// * `border_constant`: If [EdgeMode::Constant] border will be replaced with
+///   this provided [Scalar] value
 /// * `channels`: see [FastBlurChannels] for more info
 /// * `threading_policy`: see [ThreadingPolicy] for more info
 ///
 /// returns: ()
-///
 pub fn laplacian(
     image: &[u8],
     image_stride: usize,

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -143,13 +143,13 @@ pub use gaussian::gaussian_blur_f16;
 pub use gaussian::gaussian_blur_f32;
 pub use gaussian::gaussian_blur_in_linear;
 pub use gaussian::gaussian_blur_u16;
-pub use gaussian::get_gaussian_kernel_1d;
-pub use gaussian::get_sigma_size;
+pub use gaussian::gaussian_kernel_1d;
+pub use gaussian::sigma_size;
 pub use gaussian::ConvolutionMode;
 #[cfg(feature = "image")]
 pub use gaussian_blur_image::gaussian_blur_image;
 pub use img_size::ImageSize;
-pub use laplacian::{get_laplacian_kernel, laplacian};
+pub use laplacian::{laplacian, laplacian_kernel};
 pub use median_blur::median_blur;
 pub use motion_blur::{generate_motion_kernel, motion_blur};
 pub use sobel::sobel;

--- a/src/lib/median_blur.rs
+++ b/src/lib/median_blur.rs
@@ -388,14 +388,14 @@ pub fn median_blur(
         src_stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     check_slice_size(
         dst,
         dst_stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let unsafe_dst = UnsafeSlice::new(dst);
     let _dispatcher = match channels {

--- a/src/lib/stack_blur_linear.rs
+++ b/src/lib/stack_blur_linear.rs
@@ -69,10 +69,10 @@ pub fn stack_blur_in_linear(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let mut linear_data: Vec<f32> =
-        vec![0f32; width as usize * height as usize * channels.get_channels()];
+        vec![0f32; width as usize * height as usize * channels.channels()];
 
     let forward_transformer = match channels {
         FastBlurChannels::Plane => plane_to_linear,
@@ -90,7 +90,7 @@ pub fn stack_blur_in_linear(
         in_place,
         stride,
         &mut linear_data,
-        width * size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * size_of::<f32>() as u32 * channels.channels() as u32,
         width,
         height,
         transfer_function,
@@ -98,7 +98,7 @@ pub fn stack_blur_in_linear(
 
     crate::stack_blur_f32(
         &mut linear_data,
-        width * channels.get_channels() as u32,
+        width * channels.channels() as u32,
         width,
         height,
         radius,
@@ -108,7 +108,7 @@ pub fn stack_blur_in_linear(
 
     inverse_transformer(
         &linear_data,
-        width * size_of::<f32>() as u32 * channels.get_channels() as u32,
+        width * size_of::<f32>() as u32 * channels.channels() as u32,
         in_place,
         stride,
         width,

--- a/src/lib/stackblur/stack_blur.rs
+++ b/src/lib/stackblur/stack_blur.rs
@@ -205,7 +205,7 @@ pub fn stack_blur(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
 
     #[allow(clippy::manual_clamp)]

--- a/src/lib/stackblur/stack_blur_f16.rs
+++ b/src/lib/stackblur/stack_blur_f16.rs
@@ -207,7 +207,7 @@ pub fn stack_blur_f16(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let radius = radius.max(1);
     let thread_count = threading_policy.thread_count(width, height) as u32;

--- a/src/lib/stackblur/stack_blur_f32.rs
+++ b/src/lib/stackblur/stack_blur_f32.rs
@@ -180,7 +180,7 @@ pub fn stack_blur_f32(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     let radius = radius.max(1);
     let thread_count = threading_policy.thread_count(width, height) as u32;

--- a/src/lib/stackblur/stack_blur_u16.rs
+++ b/src/lib/stackblur/stack_blur_u16.rs
@@ -143,7 +143,7 @@ pub fn stack_blur_u16(
         stride as usize,
         width as usize,
         height as usize,
-        channels.get_channels(),
+        channels.channels(),
     )?;
     #[allow(clippy::manual_clamp)]
     let radius = radius.max(1).min(2000);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,9 @@ use fast_transpose::{transpose_rgba, FlipMode, FlopMode};
 use image::imageops::FilterType;
 use image::{DynamicImage, EncodableLayout, GenericImageView, ImageReader};
 use libblur::{
-    fast_gaussian, filter_1d_exact, filter_2d_rgb_fft, generate_motion_kernel,
-    get_gaussian_kernel_1d, get_sigma_size, laplacian, motion_blur, sobel, ConvolutionMode,
-    EdgeMode, FastBlurChannels, ImageSize, KernelShape, Scalar, ThreadingPolicy,
+    fast_gaussian, filter_1d_exact, filter_2d_rgb_fft, gaussian_kernel_1d, generate_motion_kernel,
+    laplacian, motion_blur, sigma_size, sobel, ConvolutionMode, EdgeMode, FastBlurChannels,
+    ImageSize, KernelShape, Scalar, ThreadingPolicy,
 };
 use std::time::Instant;
 
@@ -95,7 +95,7 @@ fn perform_planar_pass_3(img: &[u8], width: usize, height: usize) -> Vec<u8> {
 
     println!("libblur::gaussian_blur: {:?}", start.elapsed());
 
-    let kernel = get_gaussian_kernel_1d(kernel_size, get_sigma_size(kernel_size as usize));
+    let kernel = gaussian_kernel_1d(kernel_size, sigma_size(kernel_size as usize));
 
     let start = Instant::now();
 
@@ -158,7 +158,7 @@ fn perform_planar_pass_3(img: &[u8], width: usize, height: usize) -> Vec<u8> {
 }
 
 fn main() {
-    let mut dyn_image = ImageReader::open("assets/test_image_2.png")
+    let dyn_image = ImageReader::open("assets/test_image_2.png")
         .unwrap()
         .decode()
         .unwrap();
@@ -339,7 +339,7 @@ fn main() {
 
     // dst_bytes = perform_planar_pass_3(&bytes, dimensions.0 as usize, dimensions.1 as usize);
 
-    // let kernel = get_gaussian_kernel_1d(51, get_sigma_size(51));
+    // let kernel = gaussian_kernel_1d(51, get_sigma_size(51));
     // // // dst_bytes.fill(0);
     // //
     // // let sobel_horizontal: [i16; 3] = [-1, 0, 1];


### PR DESCRIPTION
Rust [has official rules on when to use `get_` prefixes](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter) in public APIs (very narrow). :grin: